### PR TITLE
Add MCP server with Entra ID auth and update documentation for msdocs-fastapi-postgresql-sample-app

### DIFF
--- a/GUIDE_AUTH_MCP_SERVER.md
+++ b/GUIDE_AUTH_MCP_SERVER.md
@@ -1,0 +1,1048 @@
+# Guide: Enabling Entra ID Authentication for an Azure App Service MCP Server
+
+This guide documents the end-to-end steps to secure a **FastMCP (Model Context Protocol)** server running on **Azure App Service** with **Microsoft Entra ID** authentication, and preauthorize **Azure AI Foundry** agent identities to call it.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Add MCP Server to FastAPI App](#2-add-mcp-server-to-fastapi-app)
+3. [Deploy to Azure App Service](#3-deploy-to-azure-app-service)
+4. [Create Entra ID App Registration](#4-create-entra-id-app-registration)
+5. [Enable App Service Authentication (EasyAuth)](#5-enable-app-service-authentication-easyauth)
+6. [Configure Protected Resource Metadata (PRM)](#6-configure-protected-resource-metadata-prm)
+7. [Preauthorize Foundry Agent Identities](#7-preauthorize-foundry-agent-identities)
+8. [Verification & Testing](#8-verification--testing)
+9. [Troubleshooting](#9-troubleshooting)
+10. [Test Cases](#10-test-cases)
+
+---
+
+## 1. Prerequisites
+
+- Azure subscription
+- Azure CLI (`az`) and Azure Developer CLI (`azd`) installed
+- A FastAPI application deployed (or ready to deploy) to Azure App Service
+- Python 3.11+ with `mcp[cli]` package
+- Azure AI Foundry project with an agent configured
+
+**Key identifiers used throughout this guide** (replace with your own):
+
+| Item | Value |
+|------|-------|
+| Subscription ID | `1577b43a-6b5c-4c1d-845e-2e50d692189b` |
+| Resource Group | `saiyo-rg` |
+| App Service Name | `saiyo-rjdd6dwlkawae-app-service` |
+| Tenant ID | `6907edd8-11e5-421c-8f84-a3c0bd847a11` |
+| App Registration Name | `saiyo-mcp-server-auth` |
+| App (Client) ID | `428b00cd-3f42-439a-bd47-15b287a6ef1e` |
+| App Object ID | `5734980a-fe93-46a7-8a8c-c9fc70bce637` |
+| Service Principal ID | `9d820733-4882-4aa9-94d2-4a1feb5e79b2` |
+| Agent Identity (mslearnagent) | `2286091f-3967-4486-a80f-19f3cfe66721` |
+| Project Identity | `d60af655-ccb3-4b23-88c3-346eb5558280` |
+
+---
+
+## 2. Add MCP Server to FastAPI App
+
+### 2.1 Add `mcp[cli]` to dependencies
+
+In `pyproject.toml`:
+```toml
+dependencies = [
+    "mcp[cli]",
+    # ... other deps
+]
+```
+
+### 2.2 Create `mcp_server.py`
+
+Create `src/fastapi_app/mcp_server.py`:
+
+```python
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+from sqlalchemy.sql import func
+from sqlmodel import Session, select
+
+from .models import Restaurant, Review, engine
+
+# stateless_http=True is required for mounting under FastAPI
+mcp = FastMCP("RestaurantReviewsMCP", stateless_http=True)
+
+# Lifespan context manager - starts/stops MCP session manager with the FastAPI app
+@asynccontextmanager
+async def mcp_lifespan(app):
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(mcp.session_manager.run())
+        yield
+
+# Define your MCP tools with @mcp.tool() decorator
+@mcp.tool()
+async def list_restaurants_mcp() -> list[dict]:
+    """List restaurants with their average rating and review count."""
+    def sync():
+        with Session(engine) as session:
+            # ... your DB query logic
+            pass
+    return await asyncio.to_thread(sync)
+
+# ... more tools
+```
+
+### 2.3 Mount MCP in `app.py`
+
+```python
+from .mcp_server import mcp, mcp_lifespan
+
+app = FastAPI(lifespan=mcp_lifespan)
+app.mount("/mcp", mcp.streamable_http_app())
+```
+
+### 2.4 Ensure gunicorn worker has `lifespan: "on"`
+
+In `my_uvicorn_worker.py`, the MCP session manager requires lifespan events:
+
+```python
+class MyUvicornWorker(UvicornWorker):
+    CONFIG_KWARGS = {
+        "loop": "asyncio",
+        "http": "auto",
+        "lifespan": "on",      # CRITICAL: must be "on" for MCP
+        "log_config": logconfig_dict,
+    }
+```
+
+> **Without `"lifespan": "on"`, the MCP session manager won't start in production (gunicorn), and all MCP requests will fail.**
+
+---
+
+## 3. Deploy to Azure App Service
+
+```bash
+azd auth login --use-device-code
+azd up
+```
+
+### Verify MCP endpoint (before auth)
+
+```bash
+# Should return JSON-RPC response
+curl -X POST https://<APP_NAME>.azurewebsites.net/mcp/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+      "protocolVersion": "2025-03-26",
+      "capabilities": {},
+      "clientInfo": {"name": "test", "version": "1.0"}
+    }
+  }'
+```
+
+---
+
+## 4. Create Entra ID App Registration
+
+### 4.1 Create the app registration
+
+```bash
+az ad app create --display-name "saiyo-mcp-server-auth" \
+  --sign-in-audience AzureADMyOrg
+```
+
+Save the output `appId` (client ID) and `id` (object ID).
+
+### 4.2 Add an Application ID URI
+
+```bash
+APP_CLIENT_ID="428b00cd-3f42-439a-bd47-15b287a6ef1e"
+az ad app update --id $APP_CLIENT_ID \
+  --identifier-uris "api://$APP_CLIENT_ID"
+```
+
+### 4.3 Add a delegated permission scope (`user_impersonation`)
+
+```bash
+az rest --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/applications/<APP_OBJECT_ID>" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "api": {
+      "oauth2PermissionScopes": [{
+        "adminConsentDescription": "Allow the application to access the MCP server on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access MCP Server",
+        "id": "<GENERATE-A-UUID>",
+        "isEnabled": true,
+        "type": "User",
+        "userConsentDescription": "Allow the application to access the MCP server on your behalf.",
+        "userConsentDisplayName": "Access MCP Server",
+        "value": "user_impersonation"
+      }]
+    }
+  }'
+```
+
+### 4.4 Add an Application role (`MCP.Access`) for client_credentials flow
+
+This is **required** for managed identity / service principal access (like Foundry agents):
+
+```bash
+az rest --method PATCH \
+  --uri "https://graph.microsoft.com/v1.0/applications/<APP_OBJECT_ID>" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "appRoles": [{
+      "id": "<GENERATE-A-UUID>",
+      "allowedMemberTypes": ["Application"],
+      "displayName": "MCP.Access",
+      "description": "Allow application to access MCP server",
+      "isEnabled": true,
+      "value": "MCP.Access"
+    }]
+  }'
+```
+
+### 4.5 Create a client secret
+
+```bash
+az ad app credential reset --id $APP_CLIENT_ID --append
+```
+
+Save the `password` — you'll need it for App Service auth config.
+
+### 4.6 Create the Service Principal
+
+> **This step is often missed!** Without a service principal, app role assignments will fail.
+
+```bash
+az ad sp create --id $APP_CLIENT_ID
+```
+
+Or via Graph API:
+```bash
+az rest --method POST \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals" \
+  --headers "Content-Type=application/json" \
+  --body '{"appId": "'$APP_CLIENT_ID'"}'
+```
+
+---
+
+## 5. Enable App Service Authentication (EasyAuth)
+
+### 5.1 Set the client secret as an app setting
+
+```bash
+az webapp config appsettings set \
+  --name <APP_NAME> --resource-group <RG> \
+  --settings MICROSOFT_PROVIDER_AUTHENTICATION_SECRET="<CLIENT_SECRET>"
+```
+
+### 5.2 Configure EasyAuth via ARM API
+
+```bash
+SUBSCRIPTION="1577b43a-6b5c-4c1d-845e-2e50d692189b"
+RG="saiyo-rg"
+APP="saiyo-rjdd6dwlkawae-app-service"
+APP_CLIENT_ID="428b00cd-3f42-439a-bd47-15b287a6ef1e"
+TENANT_ID="6907edd8-11e5-421c-8f84-a3c0bd847a11"
+
+# Get a management token
+TOKEN=$(az account get-access-token --resource https://management.azure.com --query accessToken -o tsv)
+
+# PUT the auth config
+curl -X PUT \
+  "https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/config/authsettingsV2?api-version=2024-04-01" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+  "properties": {
+    "platform": {
+      "enabled": true,
+      "runtimeVersion": "~2"
+    },
+    "globalValidation": {
+      "requireAuthentication": true,
+      "unauthenticatedClientAction": "Return401",
+      "redirectToProvider": "azureActiveDirectory"
+    },
+    "identityProviders": {
+      "azureActiveDirectory": {
+        "enabled": true,
+        "registration": {
+          "openIdIssuer": "https://sts.windows.net/'$TENANT_ID'/v2.0",
+          "clientId": "'$APP_CLIENT_ID'",
+          "clientSecretSettingName": "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+        },
+        "validation": {
+          "allowedAudiences": [
+            "api://'$APP_CLIENT_ID'",
+            "'$APP_CLIENT_ID'"
+          ],
+          "jwtClaimChecks": {
+            "allowedClientApplications": [
+              "<AGENT_IDENTITY_ID>",
+              "<PROJECT_IDENTITY_ID>"
+            ]
+          }
+        }
+      }
+    },
+    "login": {
+      "tokenStore": {
+        "enabled": true
+      }
+    }
+  }
+}'
+```
+
+**Key settings explained:**
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `runtimeVersion` | `~2` | **Must be `~2`** — version `~1` doesn't properly enforce auth |
+| `unauthenticatedClientAction` | `Return401` | Returns 401 instead of redirecting to login page |
+| `allowedAudiences` | `api://<clientId>`, `<clientId>` | Accept tokens targeting either audience format |
+| `allowedClientApplications` | Agent & Project IDs | Only these clients can call the API |
+| `clientSecretSettingName` | `MICROSOFT_PROVIDER_AUTHENTICATION_SECRET` | References the app setting holding the secret |
+
+### 5.3 Restart the App Service
+
+After changing auth config, restart to ensure it takes effect:
+
+```bash
+az webapp stop --name $APP --resource-group $RG
+sleep 10
+az webapp start --name $APP --resource-group $RG
+```
+
+### 5.4 Verify auth is enforced
+
+```bash
+# Should return 401
+curl -s -o /dev/null -w "%{http_code}" "https://$APP.azurewebsites.net/"
+```
+
+---
+
+## 6. Configure Protected Resource Metadata (PRM)
+
+PRM tells MCP clients (like Foundry) how to authenticate. It's served automatically by EasyAuth when configured with the `WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES` app setting.
+
+```bash
+az webapp config appsettings set \
+  --name $APP --resource-group $RG \
+  --settings WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES="api://$APP_CLIENT_ID/user_impersonation"
+```
+
+### Verify PRM endpoint
+
+```bash
+# This endpoint is served WITHOUT auth (by design)
+curl -s "https://$APP.azurewebsites.net/.well-known/oauth-protected-resource"
+```
+
+Expected response:
+```json
+{
+  "resource": "https://<APP_NAME>.azurewebsites.net",
+  "authorization_servers": [
+    "https://login.microsoftonline.com/<TENANT_ID>/v2.0"
+  ],
+  "scopes_supported": [
+    "api://<CLIENT_ID>/user_impersonation"
+  ]
+}
+```
+
+---
+
+## 7. Preauthorize Foundry Agent Identities
+
+Azure AI Foundry agents use **managed identities** (type `ServiceIdentity`) that authenticate via **client_credentials** flow. They need:
+
+1. An **app role** on your app registration (not a delegated scope)
+2. An **app role assignment** granting them that role
+3. To be listed in EasyAuth's **`allowedClientApplications`**
+
+### 7.1 Look up Foundry identity details
+
+```bash
+# Get the agent and project identity details
+az rest --method GET \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/<AGENT_PRINCIPAL_ID>?$select=appId,displayName,servicePrincipalType"
+
+az rest --method GET \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/<PROJECT_PRINCIPAL_ID>?$select=appId,displayName,servicePrincipalType"
+```
+
+For `ServiceIdentity` types, `appId == principalId`.
+
+### 7.2 Grant app role assignments
+
+```bash
+OUR_SP_ID="9d820733-4882-4aa9-94d2-4a1feb5e79b2"  # SP of your app registration
+ROLE_ID="d3f07651-a73f-45cd-b8a3-73f0304890de"      # MCP.Access role ID
+
+# Agent identity
+az rest --method POST \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/<AGENT_PID>/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "principalId": "<AGENT_PID>",
+    "resourceId": "'$OUR_SP_ID'",
+    "appRoleId": "'$ROLE_ID'"
+  }'
+
+# Project identity
+az rest --method POST \
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/<PROJECT_PID>/appRoleAssignments" \
+  --headers "Content-Type=application/json" \
+  --body '{
+    "principalId": "<PROJECT_PID>",
+    "resourceId": "'$OUR_SP_ID'",
+    "appRoleId": "'$ROLE_ID'"
+  }'
+```
+
+### 7.3 Note on `preAuthorizedApplications`
+
+`ServiceIdentity` type principals **cannot** be added to the app registration's `api.preAuthorizedApplications` — you'll get an `InvalidAppId` error. This is expected. The **app role assignment + EasyAuth `allowedClientApplications`** combination is the correct approach for managed identities.
+
+---
+
+## 8. Verification & Testing
+
+### 8.1 Verify EasyAuth configuration
+
+```python
+import requests, json
+
+TOKEN = "<management-api-token>"
+url = f"https://management.azure.com/subscriptions/{SUB}/resourceGroups/{RG}/providers/Microsoft.Web/sites/{APP}/config/authsettingsV2?api-version=2024-04-01"
+resp = requests.get(url, headers={"Authorization": f"Bearer {TOKEN}"})
+aad = resp.json()['properties']['identityProviders']['azureActiveDirectory']
+
+# Check these are populated:
+print(aad['validation']['allowedAudiences'])
+# ['api://428b00cd-...', '428b00cd-...']
+
+print(aad['validation']['jwtClaimChecks']['allowedClientApplications'])
+# ['2286091f-...', 'd60af655-...']
+```
+
+### 8.2 Verify app role assignments
+
+```python
+for pid in [AGENT_PID, PROJECT_PID]:
+    resp = requests.get(
+        f"https://graph.microsoft.com/v1.0/servicePrincipals/{pid}/appRoleAssignments",
+        headers={"Authorization": f"Bearer {GRAPH_TOKEN}"}
+    )
+    for a in resp.json()['value']:
+        print(f"{a['principalDisplayName']} -> {a['resourceDisplayName']}: {a['appRoleId']}")
+```
+
+### 8.3 Check Entra ID sign-in logs
+
+In the **Azure Portal** → **Microsoft Entra ID** → **Sign-in logs** → **Service principal sign-ins**:
+- Filter by **Application** = your Foundry identity name
+- Look for **Status: Success** with **Resource** = `saiyo-mcp-server-auth`
+
+### 8.4 Check Foundry agent tool enumeration
+
+In Azure AI Foundry, run the agent. A successful `mcp_list_tools` span shows:
+```json
+{
+  "status": {"status_code": "OK"},
+  "attributes": {
+    "server_label": "connect2mcp",
+    "tools": [
+      {"name": "list_restaurants_mcp", ...},
+      {"name": "get_details_mcp", ...},
+      ...
+    ]
+  }
+}
+```
+
+---
+
+## 9. Troubleshooting
+
+### "Initialization timed out" from Foundry
+
+**Possible causes:**
+
+| Cause | How to check | Fix |
+|-------|-------------|-----|
+| No service principal for app registration | `az ad sp list --filter "appId eq '<CLIENT_ID>'"` returns empty | `az ad sp create --id <CLIENT_ID>` |
+| No app role defined | Check `appRoles` on app registration | Add `MCP.Access` app role (Section 4.4) |
+| No role assignment for Foundry identities | Check `appRoleAssignments` per SP | Grant role (Section 7.2) |
+| Missing `allowedClientApplications` in EasyAuth | Check auth config via ARM API | Add identity IDs (Section 5.2) |
+| `runtimeVersion` is `~1` | Check auth config | Change to `~2` and restart app |
+| `lifespan` is `"off"` in gunicorn worker | Check `my_uvicorn_worker.py` | Set to `"on"` and redeploy |
+| App cold start timeout | Check App Service logs | Scale up or use Always On |
+
+### Reading App Service logs
+
+```python
+# Via Kudu API
+import requests
+
+KUDU_TOKEN = "<management-token>"
+headers = {"Authorization": f"Bearer {KUDU_TOKEN}"}
+
+# List log files
+resp = requests.get(f"https://{APP}.scm.azurewebsites.net/api/vfs/LogFiles/", headers=headers)
+for f in resp.json():
+    print(f['name'], f.get('size'))
+
+# Read specific logs
+for log_name in ['_default_docker.log', '_easyauth_docker.log', '_docker.log']:
+    # Find the matching file and read it
+    pass
+
+# Application diagnostics
+resp = requests.get(
+    f"https://{APP}.scm.azurewebsites.net/api/vfs/LogFiles/Application/",
+    headers=headers
+)
+```
+
+**Key log files:**
+- `*_default_docker.log` — Application stdout (gunicorn/uvicorn startup, MCP session manager start)
+- `*_easyauth_docker.log` — Authentication middleware logs
+- `*_docker.log` — Container startup/shutdown
+- `Application/diagnostics-*.txt` — Detailed request-level logs (HTTP status codes, timings)
+
+### Verify MCP endpoint works (with auth disabled temporarily)
+
+```bash
+# Temporarily disable auth
+az rest --method PUT \
+  --uri "https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/config/authsettingsV2?api-version=2024-04-01" \
+  # ... set platform.enabled = false
+
+# Test MCP
+curl -X POST "https://$APP.azurewebsites.net/mcp/mcp" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
+
+# Re-enable auth after testing!
+```
+
+---
+
+## 10. Test Cases
+
+### Setup: Variables used across all tests
+
+```bash
+APP="saiyo-rjdd6dwlkawae-app-service"
+APP_URL="https://$APP.azurewebsites.net"
+MCP_URL="$APP_URL/mcp/mcp"
+PRM_URL="$APP_URL/.well-known/oauth-protected-resource"
+APP_CLIENT_ID="428b00cd-3f42-439a-bd47-15b287a6ef1e"
+TENANT_ID="6907edd8-11e5-421c-8f84-a3c0bd847a11"
+SUBSCRIPTION="1577b43a-6b5c-4c1d-845e-2e50d692189b"
+RG="saiyo-rg"
+
+# MCP initialize payload (reused in multiple tests)
+MCP_INIT='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}'
+
+# MCP tools/list payload
+MCP_TOOLS='{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+```
+
+---
+
+### Test Group A: Without Authentication (auth disabled)
+
+> Temporarily disable auth for these tests, then re-enable.
+
+```bash
+# Disable auth
+az rest --method PUT \
+  --uri "https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/config/authsettingsV2?api-version=2024-04-01" \
+  --headers "Content-Type=application/json" \
+  --body '{"properties":{"platform":{"enabled":false}}}'
+
+sleep 10  # Wait for config to propagate
+```
+
+#### Test A1: Root endpoint returns 200 (no auth required)
+
+```bash
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL/")
+echo "Test A1 - Root without auth: $STATUS"
+# EXPECTED: 200
+```
+
+#### Test A2: PRM endpoint not available when auth is off
+
+```bash
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PRM_URL")
+echo "Test A2 - PRM without auth: $STATUS"
+# EXPECTED: 404 (PRM is served by EasyAuth, not the app)
+```
+
+#### Test A3: MCP initialize without auth
+
+```bash
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$MCP_INIT")
+echo "Test A3 - MCP init without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with serverInfo, protocolVersion, capabilities
+```
+
+#### Test A4: MCP tools/list without auth
+
+```bash
+# First initialize to get a session (for stateful), or call directly (stateless)
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$MCP_TOOLS")
+echo "Test A4 - MCP tools/list without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with list of 4 tools
+```
+
+#### Test A5: MCP tool call — list_restaurants_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_restaurants_mcp","arguments":{}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$CALL_PAYLOAD")
+echo "Test A5 - Tool call without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with restaurant data from database
+```
+
+#### Test A6: MCP tool call — get_details_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_details_mcp","arguments":{"restaurant_id":1}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$CALL_PAYLOAD")
+echo "Test A6 - get_details without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with restaurant details and reviews
+```
+
+#### Test A7: MCP tool call — create_review_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"create_review_mcp","arguments":{"restaurant_id":1,"user_name":"TestUser","rating":5,"review_text":"Great food!"}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$CALL_PAYLOAD")
+echo "Test A7 - create_review without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with created review object
+```
+
+#### Test A8: MCP tool call — create_restaurant_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"create_restaurant_mcp","arguments":{"restaurant_name":"Test Restaurant","street_address":"123 Test St","description":"A test restaurant"}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$CALL_PAYLOAD")
+echo "Test A8 - create_restaurant without auth:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with created restaurant object
+```
+
+```bash
+# RE-ENABLE AUTH after tests
+az rest --method GET \
+  --uri "https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/config/authsettingsV2?api-version=2024-04-01" \
+  -o /tmp/auth_config.json
+
+# Edit /tmp/auth_config.json to set platform.enabled = true, then:
+az rest --method PUT \
+  --uri "https://management.azure.com/subscriptions/$SUBSCRIPTION/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/config/authsettingsV2?api-version=2024-04-01" \
+  --headers "Content-Type=application/json" \
+  --body @/tmp/auth_config.json
+
+sleep 10
+```
+
+---
+
+### Test Group B: With Authentication (auth enabled)
+
+#### Test B1: Unauthenticated request returns 401
+
+```bash
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$APP_URL/")
+echo "Test B1 - Root without token: $STATUS"
+# EXPECTED: 401
+```
+
+#### Test B2: PRM endpoint is accessible without auth
+
+```bash
+RESPONSE=$(curl -s "$PRM_URL")
+echo "Test B2 - PRM endpoint:"
+echo "$RESPONSE" | python3 -m json.tool
+# EXPECTED: 200 with JSON containing resource, authorization_servers, scopes_supported
+# {
+#   "resource": "https://saiyo-rjdd6dwlkawae-app-service.azurewebsites.net",
+#   "authorization_servers": ["https://login.microsoftonline.com/<TENANT>/v2.0"],
+#   "scopes_supported": ["api://428b00cd-.../user_impersonation"]
+# }
+```
+
+#### Test B3: MCP endpoint returns 401 without token
+
+```bash
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d "$MCP_INIT")
+echo "Test B3 - MCP without token: $STATUS"
+# EXPECTED: 401
+```
+
+#### Test B4: Request with invalid/expired token returns 401
+
+```bash
+FAKE_TOKEN="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.fake"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $FAKE_TOKEN" \
+  -d "$MCP_INIT")
+echo "Test B4 - MCP with fake token: $STATUS"
+# EXPECTED: 401
+```
+
+#### Test B5: Token with wrong audience returns 401
+
+```bash
+# Get a token for a different resource (management API), not our app
+WRONG_TOKEN=$(az account get-access-token --resource https://management.azure.com --query accessToken -o tsv)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $WRONG_TOKEN" \
+  -d "$MCP_INIT")
+echo "Test B5 - MCP with wrong-audience token: $STATUS"
+# EXPECTED: 401 (audience mismatch)
+```
+
+#### Test B6: Token with correct audience — MCP initialize succeeds
+
+```bash
+# Get a token for the correct audience
+# Option 1: Using az cli (interactive user flow)
+TOKEN=$(az account get-access-token \
+  --resource "api://$APP_CLIENT_ID" \
+  --query accessToken -o tsv)
+
+# Option 2: Using client_credentials (app-to-app)
+# TOKEN=$(curl -s -X POST "https://login.microsoftonline.com/$TENANT_ID/oauth2/v2/token" \
+#   -d "client_id=<CLIENT_ID>&client_secret=<SECRET>&scope=api://$APP_CLIENT_ID/.default&grant_type=client_credentials" \
+#   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$MCP_INIT")
+echo "Test B6 - MCP init with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with serverInfo, capabilities
+```
+
+#### Test B7: Authenticated MCP tools/list
+
+```bash
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$MCP_TOOLS")
+echo "Test B7 - tools/list with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response listing 4 tools:
+#   list_restaurants_mcp, get_details_mcp, create_review_mcp, create_restaurant_mcp
+```
+
+#### Test B8: Authenticated tool call — list_restaurants_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_restaurants_mcp","arguments":{}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$CALL_PAYLOAD")
+echo "Test B8 - list_restaurants with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with restaurant list from database
+```
+
+#### Test B9: Authenticated tool call — get_details_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_details_mcp","arguments":{"restaurant_id":1}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$CALL_PAYLOAD")
+echo "Test B9 - get_details with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with restaurant + reviews
+```
+
+#### Test B10: Authenticated tool call — create_review_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"create_review_mcp","arguments":{"restaurant_id":1,"user_name":"AuthTestUser","rating":4,"review_text":"Tested with auth!"}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$CALL_PAYLOAD")
+echo "Test B10 - create_review with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with the created review object
+```
+
+#### Test B11: Authenticated tool call — create_restaurant_mcp
+
+```bash
+CALL_PAYLOAD='{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"create_restaurant_mcp","arguments":{"restaurant_name":"Auth Test Place","street_address":"456 Secure Blvd","description":"Created with authentication"}}}'
+RESPONSE=$(curl -s -X POST "$MCP_URL" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d "$CALL_PAYLOAD")
+echo "Test B11 - create_restaurant with valid token:"
+echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE"
+# EXPECTED: JSON-RPC response with the created restaurant object
+```
+
+---
+
+### Test Group C: MCP Python Client (programmatic)
+
+#### Test C1: Full MCP client test without auth
+
+```python
+"""Run with auth disabled. Requires: pip install mcp"""
+import asyncio
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
+APP_URL = "https://saiyo-rjdd6dwlkawae-app-service.azurewebsites.net/mcp/mcp"
+
+async def test_no_auth():
+    async with streamablehttp_client(APP_URL) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            print(f"Server: {session.server_info}")
+
+            tools = await session.list_tools()
+            print(f"Tools ({len(tools.tools)}):")
+            for t in tools.tools:
+                print(f"  - {t.name}: {t.description}")
+
+            # Call a tool
+            result = await session.call_tool("list_restaurants_mcp", {})
+            print(f"Restaurants: {result.content}")
+
+asyncio.run(test_no_auth())
+# EXPECTED: Prints server info, 4 tools, and restaurant data
+```
+
+#### Test C2: Full MCP client test with auth
+
+```python
+"""Run with auth enabled. Requires: pip install mcp azure-identity"""
+import asyncio
+import httpx
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
+APP_URL = "https://saiyo-rjdd6dwlkawae-app-service.azurewebsites.net/mcp/mcp"
+APP_CLIENT_ID = "428b00cd-3f42-439a-bd47-15b287a6ef1e"
+TENANT_ID = "6907edd8-11e5-421c-8f84-a3c0bd847a11"
+
+async def get_token():
+    """Get token using client credentials (replace with your client)."""
+    from azure.identity.aio import ClientSecretCredential
+    # For testing: use a client that has MCP.Access role assigned
+    credential = ClientSecretCredential(
+        tenant_id=TENANT_ID,
+        client_id="<YOUR_TEST_CLIENT_ID>",
+        client_secret="<YOUR_TEST_CLIENT_SECRET>"
+    )
+    token = await credential.get_token(f"api://{APP_CLIENT_ID}/.default")
+    await credential.close()
+    return token.token
+
+async def test_with_auth():
+    token = await get_token()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async with streamablehttp_client(APP_URL, headers=headers) as (read, write, _):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            print(f"Server: {session.server_info}")
+
+            tools = await session.list_tools()
+            print(f"Tools ({len(tools.tools)}):")
+            for t in tools.tools:
+                print(f"  - {t.name}: {t.description}")
+
+            # Call each tool
+            result = await session.call_tool("list_restaurants_mcp", {})
+            print(f"\nlist_restaurants: {result.content}")
+
+            result = await session.call_tool("get_details_mcp", {"restaurant_id": 1})
+            print(f"\nget_details: {result.content}")
+
+            result = await session.call_tool("create_review_mcp", {
+                "restaurant_id": 1,
+                "user_name": "PythonTestUser",
+                "rating": 5,
+                "review_text": "Tested via MCP Python client with auth!"
+            })
+            print(f"\ncreate_review: {result.content}")
+
+asyncio.run(test_with_auth())
+# EXPECTED: Same output as C1 — server info, tools, restaurant data
+```
+
+#### Test C3: MCP client with auth — expect failure without token
+
+```python
+"""Run with auth enabled, but no token. Should fail."""
+import asyncio
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
+APP_URL = "https://saiyo-rjdd6dwlkawae-app-service.azurewebsites.net/mcp/mcp"
+
+async def test_no_token_with_auth_enabled():
+    try:
+        async with streamablehttp_client(APP_URL) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                print("ERROR: Should not have reached here!")
+    except Exception as e:
+        print(f"Expected error: {type(e).__name__}: {e}")
+        # EXPECTED: HTTP 401 error or connection refused
+
+asyncio.run(test_no_token_with_auth_enabled())
+# EXPECTED: Exception indicating 401 Unauthorized
+```
+
+---
+
+### Test Summary Table
+
+| Test | Auth State | Token | Expected Result |
+|------|-----------|-------|-----------------|
+| A1 | Disabled | None | 200 OK |
+| A2 | Disabled | None | 404 (PRM not served) |
+| A3 | Disabled | None | MCP initialize succeeds |
+| A4 | Disabled | None | tools/list returns 4 tools |
+| A5 | Disabled | None | list_restaurants returns data |
+| A6 | Disabled | None | get_details returns data |
+| A7 | Disabled | None | create_review returns created object |
+| A8 | Disabled | None | create_restaurant returns created object |
+| B1 | Enabled | None | 401 Unauthorized |
+| B2 | Enabled | None | 200 (PRM is exempt from auth) |
+| B3 | Enabled | None | 401 Unauthorized |
+| B4 | Enabled | Fake | 401 Unauthorized |
+| B5 | Enabled | Wrong audience | 401 Unauthorized |
+| B6 | Enabled | Valid | MCP initialize succeeds |
+| B7 | Enabled | Valid | tools/list returns 4 tools |
+| B8 | Enabled | Valid | list_restaurants returns data |
+| B9 | Enabled | Valid | get_details returns data |
+| B10 | Enabled | Valid | create_review returns created object |
+| B11 | Enabled | Valid | create_restaurant returns created object |
+| C1 | Disabled | None | Python client full flow succeeds |
+| C2 | Enabled | Valid | Python client full flow succeeds |
+| C3 | Enabled | None | Python client raises 401 error |
+
+---
+
+## Architecture Summary
+
+```
+Foundry Agent (mslearnagent)
+    │
+    │ 1. Gets token via client_credentials flow
+    │    (audience: api://428b00cd-... or 428b00cd-...)
+    │    (role: MCP.Access)
+    │
+    ▼
+Azure App Service (EasyAuth ~2)
+    │
+    │ 2. Validates JWT:
+    │    ✓ Issuer matches tenant
+    │    ✓ Audience in allowedAudiences
+    │    ✓ Client appId in allowedClientApplications
+    │
+    ▼
+FastAPI + gunicorn (lifespan: on)
+    │
+    │ 3. Routes /mcp/mcp to FastMCP
+    │
+    ▼
+FastMCP (stateless_http=True)
+    │
+    │ 4. Handles MCP JSON-RPC protocol
+    │    (initialize, tools/list, tools/call)
+    │
+    ▼
+MCP Tools (list_restaurants, get_details, etc.)
+```
+
+---
+
+## Quick Reference: All Azure Configurations
+
+### App Registration (`saiyo-mcp-server-auth`)
+- **Client ID**: `428b00cd-3f42-439a-bd47-15b287a6ef1e`
+- **Application ID URI**: `api://428b00cd-3f42-439a-bd47-15b287a6ef1e`
+- **Delegated Scope**: `user_impersonation` (for interactive users)
+- **App Role**: `MCP.Access` (for managed identities / service principals)
+- **Service Principal**: `9d820733-4882-4aa9-94d2-4a1feb5e79b2`
+
+### App Service Authentication
+- **Runtime Version**: `~2`
+- **Unauthenticated Action**: Return 401
+- **Allowed Audiences**: `api://428b00cd-...`, `428b00cd-...`
+- **Allowed Client Applications**: `2286091f-...` (agent), `d60af655-...` (project)
+
+### App Settings
+- `MICROSOFT_PROVIDER_AUTHENTICATION_SECRET` — Client secret for EasyAuth
+- `WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES` — `api://428b00cd-.../user_impersonation`

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ products:
 - azure-virtual-network
 - ai-services
 urlFragment: msdocs-fastapi-postgresql-sample-app
-name: Deploy FastAPI application with PostgreSQL and MCP Server on Azure App Service (Python)
+name: Deploy FastAPI Application with PostgreSQL & MCP Server on Azure App Service with Entra Agent Identity Auth (Python)
 description: This project deploys a restaurant review web application using FastAPI with Python, Azure Database for PostgreSQL - Flexible Server, and a Model Context Protocol (MCP) server secured with Microsoft Entra ID authentication. It demonstrates how to expose MCP tools to Azure AI Foundry agents using managed identity (agent identity) authentication.
 ---
 <!-- YAML front-matter schema: https://review.learn.microsoft.com/en-us/help/contribute/samples/process/onboarding?branch=main#supported-metadata-fields-for-readmemd -->
 
-# Deploy FastAPI Application with PostgreSQL and MCP Server via Azure App Service
+# Deploy FastAPI Application with PostgreSQL & MCP Server on Azure App Service with Entra Agent Identity Auth
 
 This project deploys a web application for a restaurant review site using **FastAPI**. It includes a **Model Context Protocol (MCP)** server that exposes restaurant review tools, secured with **Microsoft Entra ID** authentication and preauthorized for **Azure AI Foundry** agent identities.
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,6 +9,9 @@ param name string
 @description('Primary location for all resources')
 param location string
 
+@description('Location for PostgreSQL Flexible Server (use a region without offer restrictions)')
+param pgLocation string = 'centralus'
+
 @secure()
 @description('PostGreSQL Server administrator password')
 param databasePassword string
@@ -32,6 +35,7 @@ module resources 'resources.bicep' = {
   params: {
     name: name
     location: location
+    pgLocation: pgLocation
     resourceToken: resourceToken
     tags: tags
     databasePassword: databasePassword

--- a/src/fastapi_app/app.py
+++ b/src/fastapi_app/app.py
@@ -21,7 +21,9 @@ if os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING"):
 
 
 # Setup FastAPI app:
-app = FastAPI()
+from .mcp_server import mcp, mcp_lifespan
+app = FastAPI(lifespan=mcp_lifespan)
+app.mount("/mcp", mcp.streamable_http_app())
 parent_path = pathlib.Path(__file__).parent.parent
 app.mount("/mount", StaticFiles(directory=parent_path / "static"), name="static")
 templates = Jinja2Templates(directory=parent_path / "templates")

--- a/src/fastapi_app/app.py
+++ b/src/fastapi_app/app.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import logging
 import os
 import pathlib
@@ -5,7 +7,7 @@ from datetime import datetime
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 from fastapi import Depends, FastAPI, Form, Request, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.sql import func
@@ -30,6 +32,125 @@ templates = Jinja2Templates(directory=parent_path / "templates")
 templates.env.globals["prod"] = os.environ.get("RUNNING_IN_PRODUCTION", False)
 # Use relative path for url_for, so that it works behind a proxy like Codespaces
 templates.env.globals["url_for"] = app.url_path_for
+
+
+# --- Auth claim/permission logging helpers ---
+
+def _decode_jwt_payload(token: str) -> dict:
+    """Decode JWT payload without verification (for logging/demo only)."""
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return {}
+        payload = parts[1]
+        # Add padding
+        payload += "=" * (4 - len(payload) % 4)
+        decoded = base64.urlsafe_b64decode(payload)
+        return json.loads(decoded)
+    except Exception:
+        return {}
+
+
+def _extract_auth_info(request: Request) -> dict:
+    """Extract auth claims from EasyAuth headers or Authorization bearer token."""
+    auth_info = {
+        "authenticated": False,
+        "auth_source": None,
+        "claims": {},
+        "permissions": [],
+        "roles": [],
+        "scopes": [],
+    }
+
+    # Check EasyAuth headers (App Service Authentication)
+    principal_name = request.headers.get("X-MS-CLIENT-PRINCIPAL-NAME")
+    principal_id = request.headers.get("X-MS-CLIENT-PRINCIPAL-ID")
+    principal_idp = request.headers.get("X-MS-CLIENT-PRINCIPAL-IDP")
+    client_principal = request.headers.get("X-MS-CLIENT-PRINCIPAL")
+
+    if principal_name or principal_id:
+        auth_info["authenticated"] = True
+        auth_info["auth_source"] = "EasyAuth"
+        auth_info["claims"]["principal_name"] = principal_name
+        auth_info["claims"]["principal_id"] = principal_id
+        auth_info["claims"]["identity_provider"] = principal_idp
+
+        # Decode the full client principal (base64-encoded JSON)
+        if client_principal:
+            try:
+                decoded = base64.b64decode(client_principal)
+                principal_data = json.loads(decoded)
+                auth_info["claims"]["full_principal"] = principal_data
+                # Extract roles from claims
+                for claim in principal_data.get("claims", []):
+                    if claim.get("typ") == "roles":
+                        auth_info["roles"].append(claim.get("val"))
+                    elif claim.get("typ") == "scp":
+                        auth_info["scopes"] = claim.get("val", "").split(" ")
+                    elif claim.get("typ") == "permissions":
+                        auth_info["permissions"].append(claim.get("val"))
+            except Exception:
+                pass
+
+    # Check Authorization header (Bearer token)
+    auth_header = request.headers.get("Authorization", "")
+    if auth_header.startswith("Bearer "):
+        token = auth_header[7:]
+        jwt_claims = _decode_jwt_payload(token)
+        if jwt_claims:
+            auth_info["authenticated"] = True
+            auth_info["auth_source"] = auth_info.get("auth_source") or "Bearer"
+            auth_info["claims"]["jwt"] = {
+                "sub": jwt_claims.get("sub"),
+                "aud": jwt_claims.get("aud"),
+                "iss": jwt_claims.get("iss"),
+                "appid": jwt_claims.get("appid") or jwt_claims.get("azp"),
+                "oid": jwt_claims.get("oid"),
+                "tid": jwt_claims.get("tid"),
+                "name": jwt_claims.get("name"),
+                "preferred_username": jwt_claims.get("preferred_username"),
+                "exp": jwt_claims.get("exp"),
+                "iat": jwt_claims.get("iat"),
+            }
+            auth_info["roles"] = jwt_claims.get("roles", [])
+            auth_info["scopes"] = jwt_claims.get("scp", "").split(" ") if jwt_claims.get("scp") else []
+            auth_info["permissions"] = jwt_claims.get("permissions", [])
+
+    return auth_info
+
+
+@app.middleware("http")
+async def log_auth_claims(request: Request, call_next):
+    """Middleware to log auth claims/permissions on every request for demo."""
+    auth_info = _extract_auth_info(request)
+    if auth_info["authenticated"]:
+        logger.info("=== AUTH INFO for %s %s ===", request.method, request.url.path)
+        logger.info("  Source: %s", auth_info["auth_source"])
+        logger.info("  Roles: %s", auth_info["roles"])
+        logger.info("  Scopes: %s", auth_info["scopes"])
+        logger.info("  Permissions: %s", auth_info["permissions"])
+        logger.info("  Claims: %s", json.dumps(auth_info["claims"], indent=2, default=str))
+    else:
+        logger.info("AUTH: No auth credentials for %s %s", request.method, request.url.path)
+    response = await call_next(request)
+    return response
+
+
+@app.get("/auth-debug", response_class=JSONResponse)
+async def auth_debug(request: Request):
+    """Debug endpoint to inspect auth claims/permissions (for demo only)."""
+    auth_info = _extract_auth_info(request)
+    return JSONResponse(content={
+        "path": str(request.url),
+        "method": request.method,
+        "auth": auth_info,
+        "headers": {
+            "X-MS-CLIENT-PRINCIPAL-NAME": request.headers.get("X-MS-CLIENT-PRINCIPAL-NAME"),
+            "X-MS-CLIENT-PRINCIPAL-ID": request.headers.get("X-MS-CLIENT-PRINCIPAL-ID"),
+            "X-MS-CLIENT-PRINCIPAL-IDP": request.headers.get("X-MS-CLIENT-PRINCIPAL-IDP"),
+            "Authorization": "Bearer <present>" if request.headers.get("Authorization") else None,
+        },
+    })
 
 
 # Dependency to get the database session

--- a/src/fastapi_app/mcp_server.py
+++ b/src/fastapi_app/mcp_server.py
@@ -1,0 +1,102 @@
+import asyncio
+import contextlib
+from contextlib import asynccontextmanager
+
+from mcp.server.fastmcp import FastMCP
+from sqlalchemy.sql import func
+from sqlmodel import Session, select
+
+from .models import Restaurant, Review, engine
+
+# Create a FastMCP server. Use stateless_http=True for simple mounting. Default path is .../mcp
+mcp = FastMCP("RestaurantReviewsMCP", stateless_http=True)
+
+# Lifespan context manager to start/stop the MCP session manager with the FastAPI app
+@asynccontextmanager
+async def mcp_lifespan(app):
+    async with contextlib.AsyncExitStack() as stack:
+        await stack.enter_async_context(mcp.session_manager.run())
+        yield
+
+# MCP tool: List all restaurants with their average rating and review count
+@mcp.tool()
+async def list_restaurants_mcp() -> list[dict]:
+    """List restaurants with their average rating and review count."""
+
+    def sync():
+        with Session(engine) as session:
+            statement = (
+                select(
+                    Restaurant,
+                    func.avg(Review.rating).label("avg_rating"),
+                    func.count(Review.id).label("review_count"),
+                )
+                .outerjoin(Review, Review.restaurant == Restaurant.id)
+                .group_by(Restaurant.id)
+            )
+            results = session.exec(statement).all()
+            rows = []
+            for restaurant, avg_rating, review_count in results:
+                r = restaurant.dict()
+                r["avg_rating"] = float(avg_rating) if avg_rating is not None else None
+                r["review_count"] = review_count
+                r["stars_percent"] = (
+                    round((float(avg_rating) / 5.0) * 100) if review_count > 0 and avg_rating is not None else 0
+                )
+                rows.append(r)
+            return rows
+
+    return await asyncio.to_thread(sync)
+
+# MCP tool: Get a restaurant and all its reviews by restaurant_id
+@mcp.tool()
+async def get_details_mcp(restaurant_id: int) -> dict:
+    """Return the restaurant and its related reviews as objects."""
+
+    def sync():
+        with Session(engine) as session:
+            restaurant = session.exec(select(Restaurant).where(Restaurant.id == restaurant_id)).first()
+            if restaurant is None:
+                return None
+            reviews = session.exec(select(Review).where(Review.restaurant == restaurant_id)).all()
+            return {"restaurant": restaurant.dict(), "reviews": [r.dict() for r in reviews]}
+
+    return await asyncio.to_thread(sync)
+
+# MCP tool: Create a new review for a restaurant
+@mcp.tool()
+async def create_review_mcp(restaurant_id: int, user_name: str, rating: int, review_text: str) -> dict:
+    """Create a new review for a restaurant and return the created review dict."""
+
+    def sync():
+        with Session(engine) as session:
+            review = Review()
+            review.restaurant = restaurant_id
+            review.review_date = __import__("datetime").datetime.now()
+            review.user_name = user_name
+            review.rating = int(rating)
+            review.review_text = review_text
+            session.add(review)
+            session.commit()
+            session.refresh(review)
+            return review.dict()
+
+    return await asyncio.to_thread(sync)
+
+# MCP tool: Create a new restaurant
+@mcp.tool()
+async def create_restaurant_mcp(restaurant_name: str, street_address: str, description: str) -> dict:
+    """Create a new restaurant and return the created restaurant dict."""
+
+    def sync():
+        with Session(engine) as session:
+            restaurant = Restaurant()
+            restaurant.name = restaurant_name
+            restaurant.street_address = street_address
+            restaurant.description = description
+            session.add(restaurant)
+            session.commit()
+            session.refresh(restaurant)
+            return restaurant.dict()
+
+    return await asyncio.to_thread(sync)

--- a/src/fastapi_app/side_car.py
+++ b/src/fastapi_app/side_car.py
@@ -1,0 +1,319 @@
+"""
+side_car.py — Demo: MCP Server on Azure App Service with Agent ID SDK Token Validation
+=======================================================================================
+
+This file demonstrates how an MCP server hosted on Azure App Service can use
+the Microsoft Entra SDK for AgentID (sidecar) for token validation instead of
+(or in addition to) EasyAuth.
+
+Architecture:
+  ┌─────────────┐     ┌─────────────────────────┐     ┌──────────────────────┐
+  │  Foundry     │────▶│  FastAPI + MCP Server    │────▶│  Agent ID SDK        │
+  │  Agent       │     │  (this file)             │     │  Sidecar             │
+  │              │◀────│  port 8000               │◀────│  http://localhost:5000│
+  └─────────────┘     └─────────────────────────┘     └──────────────────────┘
+                           │                               │
+                           │  Forwards Authorization       │  Returns validated
+                           │  header to /Validate           │  claims (oid, tid,
+                           │                               │  roles, scopes)
+                           ▼                               │
+                      ┌──────────┐                         │
+                      │ PostgreSQL│                         │
+                      └──────────┘
+
+Usage:
+  1. Deploy the Agent ID SDK sidecar (see: https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/installation)
+  2. Set environment variables:
+       SIDECAR_URL=http://localhost:5000       (Agent ID SDK endpoint)
+       AzureAd__TenantId=<your-tenant-id>
+       AzureAd__ClientId=<your-api-client-id>
+       AzureAd__Audience=api://<your-api-id>
+  3. Run:  uvicorn fastapi_app.side_car:app --host 0.0.0.0 --port 8000
+
+Reference:
+  https://learn.microsoft.com/en-us/entra/msidweb/agent-id-sdk/scenarios/validate-authorization-header
+"""
+
+import json
+import logging
+import os
+import pathlib
+from datetime import datetime
+
+import httpx
+from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.sql import func
+from sqlmodel import Session, select
+
+from .models import Restaurant, Review, engine
+from .mcp_server import mcp, mcp_lifespan
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logger = logging.getLogger("side_car")
+logger.setLevel(logging.INFO)
+
+# ---------------------------------------------------------------------------
+# Agent ID SDK sidecar configuration
+# ---------------------------------------------------------------------------
+SIDECAR_URL = os.getenv("SIDECAR_URL", "http://localhost:5000")
+
+# ---------------------------------------------------------------------------
+# FastAPI app with MCP mounted
+# ---------------------------------------------------------------------------
+app = FastAPI(
+    title="MCP Server with Agent ID SDK Token Validation",
+    lifespan=mcp_lifespan,
+)
+app.mount("/mcp", mcp.streamable_http_app())
+parent_path = pathlib.Path(__file__).parent.parent
+app.mount("/mount", StaticFiles(directory=parent_path / "static"), name="static")
+templates = Jinja2Templates(directory=parent_path / "templates")
+templates.env.globals["prod"] = os.environ.get("RUNNING_IN_PRODUCTION", False)
+templates.env.globals["url_for"] = app.url_path_for
+
+
+# ---------------------------------------------------------------------------
+# Agent ID SDK Token Validation Helper
+# ---------------------------------------------------------------------------
+async def validate_token_with_sidecar(authorization_header: str) -> dict:
+    """
+    Validate a bearer token by forwarding the Authorization header to the
+    Microsoft Entra SDK for AgentID sidecar's /Validate endpoint.
+
+    Returns the validated claims dict on success, raises HTTPException on failure.
+    """
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        response = await client.get(
+            f"{SIDECAR_URL}/Validate",
+            headers={"Authorization": authorization_header},
+        )
+
+    if response.status_code == 401:
+        logger.warning("Agent ID SDK: Token invalid or expired")
+        raise HTTPException(status_code=401, detail="Token invalid or expired")
+    if response.status_code == 403:
+        logger.warning("Agent ID SDK: Token missing required scopes")
+        raise HTTPException(status_code=403, detail="Insufficient scopes or roles")
+    if not response.is_success:
+        logger.error("Agent ID SDK: Unexpected error %s", response.status_code)
+        raise HTTPException(status_code=401, detail="Token validation failed")
+
+    return response.json()
+
+
+def extract_user_info(validation: dict) -> dict:
+    """Extract user/agent identity from the Agent ID SDK validation response."""
+    claims = validation.get("claims", {})
+    return {
+        "id": claims.get("oid"),
+        "upn": claims.get("upn"),
+        "app_id": claims.get("appid") or claims.get("azp"),
+        "tenant_id": claims.get("tid"),
+        "scopes": claims.get("scp", "").split(" ") if claims.get("scp") else [],
+        "roles": claims.get("roles", []),
+        "audience": claims.get("aud"),
+        "issuer": claims.get("iss"),
+        "claims": claims,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Middleware: Validate tokens on /mcp/** routes via Agent ID SDK sidecar
+# ---------------------------------------------------------------------------
+@app.middleware("http")
+async def agent_id_auth_middleware(request: Request, call_next):
+    """
+    Token validation middleware using the Microsoft Entra SDK for AgentID.
+
+    - Requests to /mcp/** require a valid bearer token.
+    - The token is validated by forwarding the Authorization header to the
+      Agent ID SDK sidecar at SIDECAR_URL/Validate.
+    - Validated claims are stored in request.state.user for downstream use.
+    - Non-MCP routes (web UI) pass through without token validation.
+    """
+    if request.url.path.startswith("/mcp"):
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            logger.info("AUTH: Missing bearer token for %s %s", request.method, request.url.path)
+            return JSONResponse(
+                status_code=401,
+                content={"error": "No authorization token provided"},
+            )
+
+        try:
+            validation = await validate_token_with_sidecar(auth_header)
+            user_info = extract_user_info(validation)
+            request.state.user = user_info
+
+            logger.info(
+                "=== Agent ID SDK AUTH for %s %s ===",
+                request.method,
+                request.url.path,
+            )
+            logger.info("  OID:     %s", user_info["id"])
+            logger.info("  AppID:   %s", user_info["app_id"])
+            logger.info("  Tenant:  %s", user_info["tenant_id"])
+            logger.info("  Roles:   %s", user_info["roles"])
+            logger.info("  Scopes:  %s", user_info["scopes"])
+
+        except HTTPException as exc:
+            return JSONResponse(
+                status_code=exc.status_code,
+                content={"error": exc.detail},
+            )
+        except httpx.ConnectError:
+            logger.error("Agent ID SDK sidecar unreachable at %s", SIDECAR_URL)
+            return JSONResponse(
+                status_code=503,
+                content={"error": "Agent ID SDK sidecar unavailable"},
+            )
+
+    response = await call_next(request)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Auth debug endpoint — inspect validated claims (demo only)
+# ---------------------------------------------------------------------------
+@app.get("/auth-debug", response_class=JSONResponse)
+async def auth_debug(request: Request):
+    """Debug endpoint: shows validated claims from the Agent ID SDK sidecar."""
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return JSONResponse(
+            status_code=401,
+            content={"error": "No bearer token provided"},
+        )
+
+    validation = await validate_token_with_sidecar(auth_header)
+    user_info = extract_user_info(validation)
+    return JSONResponse(content={
+        "sidecar_url": SIDECAR_URL,
+        "validation_response": validation,
+        "extracted_user": user_info,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Role-based authorization helper (for MCP tool protection)
+# ---------------------------------------------------------------------------
+def require_role(request: Request, required_role: str):
+    """Check that the validated token includes the required role."""
+    user = getattr(request.state, "user", None)
+    if not user:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    if required_role not in user.get("roles", []):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Role '{required_role}' required",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Web UI routes (no token validation — served to browsers)
+# ---------------------------------------------------------------------------
+def get_db_session():
+    with Session(engine) as session:
+        yield session
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request, session: Session = Depends(get_db_session)):
+    logger.info("root called")
+    statement = (
+        select(
+            Restaurant,
+            func.avg(Review.rating).label("avg_rating"),
+            func.count(Review.id).label("review_count"),
+        )
+        .outerjoin(Review, Review.restaurant == Restaurant.id)
+        .group_by(Restaurant.id)
+    )
+    results = session.exec(statement).all()
+
+    restaurants = []
+    for restaurant, avg_rating, review_count in results:
+        restaurant_dict = restaurant.dict()
+        restaurant_dict["avg_rating"] = avg_rating
+        restaurant_dict["review_count"] = review_count
+        restaurant_dict["stars_percent"] = (
+            round((float(avg_rating) / 5.0) * 100) if review_count > 0 else 0
+        )
+        restaurants.append(restaurant_dict)
+
+    return templates.TemplateResponse("index.html", {"request": request, "restaurants": restaurants})
+
+
+@app.get("/create", response_class=HTMLResponse)
+async def create_restaurant(request: Request):
+    return templates.TemplateResponse("create_restaurant.html", {"request": request})
+
+
+@app.post("/add", response_class=RedirectResponse)
+async def add_restaurant(
+    request: Request,
+    restaurant_name: str = Form(...),
+    street_address: str = Form(...),
+    description: str = Form(...),
+    session: Session = Depends(get_db_session),
+):
+    restaurant = Restaurant()
+    restaurant.name = restaurant_name
+    restaurant.street_address = street_address
+    restaurant.description = description
+    session.add(restaurant)
+    session.commit()
+    session.refresh(restaurant)
+    return RedirectResponse(
+        url=app.url_path_for("details", id=restaurant.id),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.get("/details/{id}", response_class=HTMLResponse)
+async def details(request: Request, id: int, session: Session = Depends(get_db_session)):
+    restaurant = session.exec(select(Restaurant).where(Restaurant.id == id)).first()
+    reviews = session.exec(select(Review).where(Review.restaurant == id)).all()
+    review_count = len(reviews)
+    avg_rating = (
+        sum(r.rating for r in reviews if r.rating is not None) / review_count
+        if review_count > 0
+        else 0
+    )
+    restaurant_dict = restaurant.dict()
+    restaurant_dict["avg_rating"] = avg_rating
+    restaurant_dict["review_count"] = review_count
+    restaurant_dict["stars_percent"] = (
+        round((float(avg_rating) / 5.0) * 100) if review_count > 0 else 0
+    )
+    return templates.TemplateResponse(
+        "details.html", {"request": request, "restaurant": restaurant_dict, "reviews": reviews}
+    )
+
+
+@app.post("/review/{id}", response_class=RedirectResponse)
+async def add_review(
+    request: Request,
+    id: int,
+    user_name: str = Form(...),
+    rating: str = Form(...),
+    review_text: str = Form(...),
+    session: Session = Depends(get_db_session),
+):
+    review = Review()
+    review.restaurant = id
+    review.review_date = datetime.now()
+    review.user_name = user_name
+    review.rating = int(rating)
+    review.review_text = review_text
+    session.add(review)
+    session.commit()
+    return RedirectResponse(
+        url=app.url_path_for("details", id=id),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )

--- a/src/my_uvicorn_worker.py
+++ b/src/my_uvicorn_worker.py
@@ -45,6 +45,6 @@ class MyUvicornWorker(UvicornWorker):
     CONFIG_KWARGS = {
         "loop": "asyncio",
         "http": "auto",
-        "lifespan": "off",
+        "lifespan": "on",
         "log_config": logconfig_dict,
     }

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "python-multipart",
     "psycopg2",
     "sqlmodel",
+    "mcp[cli]",
 ]
 
 [build-system]


### PR DESCRIPTION
This pull request introduces major enhancements to the FastAPI restaurant review application by integrating a Model Context Protocol (MCP) server, enabling Azure AI Foundry agent access via Microsoft Entra ID authentication, and updating the infrastructure to support these features. It also improves documentation with a comprehensive setup and deployment guide.

**Key changes include:**

## Summary

Add a Model Context Protocol (MCP) server to the existing FastAPI restaurant reviews sample app, secure it with Microsoft Entra ID authentication (EasyAuth v2), and preauthorize Azure AI Foundry agent identities to call the MCP tools using managed identity (`ServiceIdentity`) authentication via the `client_credentials` flow.

## Motivation

Azure AI Foundry agents need to consume MCP servers hosted on Azure App Service. The existing sample app needs to demonstrate how to secure an MCP endpoint for agent identity access to reduce the risk of agentic threats. This change provides a working, end-to-end example that developers can follow to:

1. Add an MCP server to an existing FastAPI app
2. Secure it with Entra ID authentication
3. Preauthorize Foundry agent identities (which use `ServiceIdentity` type principals, not standard app registrations)

## Changes

### New Files
- **`src/fastapi_app/mcp_server.py`** — MCP server with 4 tools (`list_restaurants_mcp`, `get_details_mcp`, `create_review_mcp`, `create_restaurant_mcp`) using `FastMCP` with `stateless_http=True`
- **`GUIDE_AUTH_MCP_SERVER.md`** — Comprehensive step-by-step guide covering app registration, EasyAuth configuration, PRM setup, Foundry agent preauthorization, verification, troubleshooting, and 22 test cases

### Modified Files
- **`src/pyproject.toml`** — Added `mcp[cli]` to dependencies
- **`src/fastapi_app/app.py`** — Imported and mounted MCP server at `/mcp`, added `mcp_lifespan` context manager to FastAPI app
- **`src/my_uvicorn_worker.py`** — Changed `lifespan` from `"auto"` to `"on"` (required for MCP session manager to start under gunicorn)
- **`README.md`** — Updated title, description, and added sections for MCP tools, architecture diagram, local MCP verification, Entra ID auth setup steps, Foundry agent integration, and key learnings
- **`infra/main.bicep`**, **`infra/resources.bicep`** — Infrastructure updates from `azd up` deployment

## Technical Details

### MCP Server
- Mounted at `/mcp/mcp` under the existing FastAPI app
- Uses `stateless_http=True` for compatibility with FastAPI mount
- `mcp_lifespan` context manager ensures the MCP session manager starts/stops with the app
- Tools use `asyncio.to_thread()` to run synchronous SQLModel/SQLAlchemy DB queries

### Authentication Architecture
Azure AI Foundry Agent
│
│ client_credentials flow → token with MCP.Access role
▼
Azure App Service (EasyAuth ~2, Return401)
│
│ JWT validated: issuer, audience, allowedClientApplications
▼
FastAPI + gunicorn (lifespan: on)
│
│ /mcp/mcp → FastMCP (stateless_http)
▼
MCP Tools → PostgreSQL


### Key Configuration

| Component | Setting | Value |
|-----------|---------|-------|
| EasyAuth | `runtimeVersion` | `~2` (v1 doesn't enforce auth properly) |
| EasyAuth | `unauthenticatedClientAction` | `Return401` |
| App Role | `MCP.Access` | `allowedMemberTypes: ["Application"]` |
| PRM | `WEBSITE_AUTH_PRM_DEFAULT_WITH_SCOPES` | `api://<client-id>/user_impersonation` |
| Gunicorn | `lifespan` | `"on"` (critical for MCP session manager) |

### Key Learnings Documented
- **`ServiceIdentity` principals** (Foundry agents) cannot be added to `preAuthorizedApplications` — use app role assignments + `allowedClientApplications` instead
- A **service principal must be created** for the app registration before role assignments work (commonly missed step)
- **`runtimeVersion: "~2"`** is required for EasyAuth to properly enforce authentication
- The **PRM endpoint** (`/.well-known/oauth-protected-resource`) is served by EasyAuth and is exempt from authentication by design

## Test Coverage

22 test cases across 3 groups:
- **Group A (8 tests):** MCP functionality without authentication (auth disabled)
- **Group B (11 tests):** Authentication enforcement — unauthenticated, fake token, wrong audience, valid token flows
- **Group C (3 tests):** Python MCP client programmatic tests (with/without auth)

## Verification

- Foundry agent (`mslearnagent`) successfully connects and enumerates all 4 MCP tools (`mcp_list_tools` status: `OK`)
- Entra ID sign-in logs show successful `ServiceIdentity` authentication
- PRM endpoint serves correct OAuth metadata
- Unauthenticated requests correctly return 401